### PR TITLE
Set up dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# Documentation for all configuration options:
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,4 @@ source "https://rubygems.org"
 # Dependencies are specified in publify_amazon_sidebar.gemspec.
 gemspec
 
-if File.exist? File.join("..", "publify_core")
-  gem "publify_core", path: "../publify_core"
-else
-  gem "publify_core", git: "https://github.com/publify/publify_core.git"
-end
+gem "publify_core", git: "https://github.com/publify/publify_core.git"


### PR DESCRIPTION
- Set up dependabot
- Always get `publify_core` from the repository in development
