### PR TITLE
Update text filter to work with the changed text filter plugin system

### DIFF
--- a/lib/publify_app/textfilter_code.rb
+++ b/lib/publify_app/textfilter_code.rb
@@ -5,7 +5,9 @@ require "htmlentities"
 
 class PublifyApp
   class Textfilter
-    class Code < TextFilterPlugin::MacroPre
+    class Code < TextFilterPlugin
+      include TextFilterPlugin::MacroPre
+
       plugin_display_name "Code"
       plugin_description "Apply coderay highlighting to a code block"
 


### PR DESCRIPTION
MacroPre is now a module that must be included.
