### PR TITLE
Restore inheritance from TextFilterPlugin::MacroPre

### DIFF
--- a/lib/publify_app/textfilter_code.rb
+++ b/lib/publify_app/textfilter_code.rb
@@ -5,9 +5,7 @@ require "htmlentities"
 
 class PublifyApp
   class Textfilter
-    class Code < TextFilterPlugin
-      include TextFilterPlugin::MacroPre
-
+    class Code < TextFilterPlugin::MacroPre
       plugin_display_name "Code"
       plugin_description "Apply coderay highlighting to a code block"
 


### PR DESCRIPTION
This is a return to the API as of Publify version 10.0.0.
