### PR TITLE
Support Ruby 3.0 and up

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -24,7 +24,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        ruby: ["3.0", "3.1", "3.2", "3.3"]
 
     steps:
       - uses: actions/checkout@v4
@@ -47,7 +47,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.2
+          ruby-version: 3.3
           bundler-cache: true
       - name: Run RuboCop
         run: bundle exec rubocop -P

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -33,7 +33,6 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-          rubygems: latest
       - name: Migrate database
         run: bundle exec rake db:create db:migrate
       - name: Run tests
@@ -50,7 +49,6 @@ jobs:
         with:
           ruby-version: 3.2
           bundler-cache: true
-          rubygems: latest
       - name: Run RuboCop
         run: bundle exec rubocop -P
       - name: Check manifest

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,7 +15,7 @@ AllCops:
     - 'spec/dummy/bin/*'
     - 'spec/dummy/db/schema.rb'
   NewCops: enable
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
 
 Rails:
   Enabled: true

--- a/publify_textfilter_code.gemspec
+++ b/publify_textfilter_code.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.files       = File.open("Manifest.txt").readlines.map(&:chomp)
 
-  s.required_ruby_version = ">= 2.7.0"
+  s.required_ruby_version = ">= 3.0.0"
 
   s.add_dependency "coderay", "~> 1.1.0"
   s.add_dependency "htmlentities", "~> 4.3"


### PR DESCRIPTION
- Drop support for Ruby 2.7
- Skip needless rubygems update in Actions
- Build with Rubies 3.0 through 3.3 in CI
